### PR TITLE
Added setter and getter for ApiClient to SsoApi

### DIFF
--- a/src/main/java/net/troja/eve/esi/api/SsoApi.java
+++ b/src/main/java/net/troja/eve/esi/api/SsoApi.java
@@ -20,13 +20,21 @@ import net.troja.eve.esi.auth.OAuth;
  */
 public class SsoApi {
     private static final String DATE_FORMAT = "yyyy-MM-dd'T'hh:mm:ss.sss";
-    private final ApiClient apiClient;
+    private ApiClient apiClient;
 
     public SsoApi() {
         this(new ApiClient());
     }
 
     public SsoApi(final ApiClient apiClient) {
+        this.apiClient = apiClient;
+    }
+
+    public ApiClient getApiClient() {
+        return apiClient;
+    }
+
+    public void setApiClient(ApiClient apiClient) {
         this.apiClient = apiClient;
     }
 


### PR DESCRIPTION
There is no longer any reason the ApiClient should be final in SsoApi
and the getter and setters can be very helpful. It also match the
methods on the other API classes