### PR TITLE
Switch to Okhttp to gain threadsafety.

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
   "invokerPackage":"net.troja.eve.esi",
   "apiPackage":"net.troja.eve.esi.api",
   "modelPackage":"net.troja.eve.esi.model",
-  "library":"jersey2",
+  "library":"okhttp-gson",
   "serializableModel":"true",
   "hideGenerationTimestamp":"true",
   "dateLibrary":"java8"


### PR DESCRIPTION
Based on [my readings](https://stackoverflow.com/questions/48532860/is-it-thread-safe-to-make-calls-to-okhttpclient-in-parallel), this should resolve #20. I think it should be an easy switch for consumers, as well, since the Swagger-generated wrapper abstracts away all of the HTTP client-specific details. This HTTP client should yield a performance improvement, as it features HTTP connection pooling by default, which the previous client was not configured to use.

I've run `./generate.sh`, which works (maven builds). I've declined to commit the rather large diff, however, as I'm not 100% confident that my dev setup matches yours.