### PR TITLE
Never use ApiClient constructor

### DIFF
--- a/.openapi-generator-ignore
+++ b/.openapi-generator-ignore
@@ -46,4 +46,4 @@ src/main/java/net/troja/eve/esi/api/SwaggerApi.java
 src/test/java/net/troja/eve/esi/api/SwaggerApiTest.java
 src/main/java/net/troja/eve/esi/api/WebUiApi.java
 src/test/java/net/troja/eve/esi/api/WebUIApiTest.java
-src/test/java/net/troja/eve/esi/Configuration.java
+src/main/java/net/troja/eve/esi/Configuration.java

--- a/.openapi-generator-ignore
+++ b/.openapi-generator-ignore
@@ -46,3 +46,4 @@ src/main/java/net/troja/eve/esi/api/SwaggerApi.java
 src/test/java/net/troja/eve/esi/api/SwaggerApiTest.java
 src/main/java/net/troja/eve/esi/api/WebUiApi.java
 src/test/java/net/troja/eve/esi/api/WebUIApiTest.java
+src/test/java/net/troja/eve/esi/Configuration.java

--- a/src/main/java/net/troja/eve/esi/Configuration.java
+++ b/src/main/java/net/troja/eve/esi/Configuration.java
@@ -12,7 +12,7 @@
 package net.troja.eve.esi;
 
 public class Configuration {
-    private static ApiClient defaultApiClient = new ApiClient();
+    private static ApiClient defaultApiClient = new ApiClientBuilder().build();
 
     /**
      * Get the default API client, which would be used when creating API

--- a/src/main/java/net/troja/eve/esi/api/SsoApi.java
+++ b/src/main/java/net/troja/eve/esi/api/SsoApi.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import net.troja.eve.esi.ApiCallback;
 import net.troja.eve.esi.ApiClient;
+import net.troja.eve.esi.ApiClientBuilder;
 import net.troja.eve.esi.ApiException;
 import net.troja.eve.esi.ApiResponse;
 import net.troja.eve.esi.Configuration;
@@ -22,7 +23,7 @@ public class SsoApi {
     private static final String REFRESH_TOKEN = "refresh_token";
     private static final String DATASOURCE = "tranquility";
     protected static final String DATE_FORMAT = "yyyy-MM-dd'T'hh:mm:ss";
-    private final ApiClient revokeApiClient = new ApiClient();
+    private final ApiClient revokeApiClient = new ApiClientBuilder().build();
     private ApiClient apiClient;
     private MetaApi metaApi;
 


### PR DESCRIPTION
Suggested fixed for ApiClient constructor still being used

Note: This will make Configuration.java be ignored on generation, that may be bad