### PR TITLE
Useragent & logging update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ esi.json
 /nbproject/
 meta.json
 dev.json
+notest.sh
+test.sh

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.troja.eve</groupId>
     <artifactId>eve-esi</artifactId>
     <version>4.7.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>EVE-ESI</name>
-    <description>Java Client for the new Eve Swagger Interface (ESI)</description>
+    <description>Java Client for the EVE Online Swagger Interface (ESI)</description>
     <url>https://github.com/burberius/eve-esi</url>
 
     <scm>
@@ -221,6 +221,12 @@
             <version>1.3</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j-version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <properties>
@@ -234,6 +240,7 @@
         <commons-lang3-version>3.12.0</commons-lang3-version>
         <javax-annotation-version>1.0</javax-annotation-version>
         <junit-version>4.13.2</junit-version>
+        <slf4j-version>1.7.7</slf4j-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/src/main/java/net/troja/eve/esi/ApiClientBuilder.java
+++ b/src/main/java/net/troja/eve/esi/ApiClientBuilder.java
@@ -17,13 +17,10 @@ public class ApiClientBuilder {
             client = new ApiClient();
         }
         // Set default User-Agent.
-        String systemUserAgent = System.getProperty("http.agent");
         if (userAgent != null && !userAgent.isEmpty()) {
             client.setUserAgent(userAgent);
-        } else if (systemUserAgent != null && !systemUserAgent.isEmpty()) {
-            client.setUserAgent(systemUserAgent);
-        } else {
-            client.setUserAgent("eve-esi/slack:@goldengnu");
+        } else  {
+            client.setUserAgent(Configuration.getUseragent());
         }
         // Set auth
         final OAuth auth = (OAuth) client.getAuthentication("evesso");

--- a/src/main/java/net/troja/eve/esi/Configuration.java
+++ b/src/main/java/net/troja/eve/esi/Configuration.java
@@ -11,9 +11,17 @@
 
 package net.troja.eve.esi;
 
-public class Configuration {
-    private static ApiClient defaultApiClient = new ApiClientBuilder().build();
+import org.apache.commons.lang3.StringUtils;
 
+public final class Configuration {
+
+    private Configuration() {
+        // no.
+    }
+
+    private static ApiClient defaultApiClient = new ApiClientBuilder().build();
+    private static String useragent;
+    
     /**
      * Get the default API client, which would be used when creating API
      * instances without providing an API client.
@@ -34,4 +42,34 @@ public class Configuration {
     public static void setDefaultApiClient(ApiClient apiClient) {
         defaultApiClient = apiClient;
     }
+
+    /**
+     * Gets the default useragent first from a system property then falling back
+     * to a known string.
+     * 
+     * @return
+     */
+    private static String getDefaultUseragent() {
+        final String sys = System.getProperty("http.agent");
+        return StringUtils.isNotBlank(sys) ? sys : "eve-esi/slack:@goldengnu";
+    }
+
+    /**
+     * Returns the useragent to use for HTTP requests.
+     * 
+     * @return useragent
+     */
+    public static String getUseragent() {
+        return StringUtils.isNotBlank(useragent) ? useragent : getDefaultUseragent();
+    }
+
+    /**
+     * Sets the useragent to use for HTTP requests.
+     * 
+     * @param useragent
+     */
+    public static void setUseragent(final String useragent) {
+        Configuration.useragent = useragent;
+    }
+
 }

--- a/src/test/java/net/troja/eve/esi/api/GeneralApiTest.java
+++ b/src/test/java/net/troja/eve/esi/api/GeneralApiTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 import org.junit.BeforeClass;
 
-public class GeneralApiTest {
+public abstract class GeneralApiTest {
     protected static final boolean IGNORE_WARNING_HEADER_199 = false;
     protected static final String DATASOURCE = "tranquility";
     protected static final String LANGUAGE = "en-us";

--- a/src/test/java/net/troja/eve/esi/api/MarketApiTest.java
+++ b/src/test/java/net/troja/eve/esi/api/MarketApiTest.java
@@ -246,6 +246,7 @@ public class MarketApiTest extends GeneralApiTest {
         //Get market orders
         ApiResponse<List<MarketOrdersResponse>> response = api.getMarketsRegionIdOrdersWithHttpInfo(orderType, REGION_ID_THE_FORGE, DATASOURCE, null, null, null);
         result.addAll(response.getData());
+        assertThat(result.size(), greaterThan(0));
 
         /**
          * Step 2: Safely get X-Pages header.
@@ -262,13 +263,10 @@ public class MarketApiTest extends GeneralApiTest {
          * For public endpoints ApiClient is fully thread safe.
          * For authorized endpoints one instance of ApiClient is required per refresh token
          */
-        for (int page = 2; page <= xPages; page++) { //For each page greater than one.
-            //Get market orders
-            List<MarketOrdersResponse> pageResponse = api.getMarketsRegionIdOrders(orderType, REGION_ID_THE_FORGE, DATASOURCE, null, page, null);
-            result.addAll(pageResponse);
-        }
+        List<MarketOrdersResponse> page2 = api.getMarketsRegionIdOrders(orderType, REGION_ID_THE_FORGE, DATASOURCE, null, 2, null);
+        assertThat(page2.size(), greaterThan(0));
 
-        assertThat(result, notNullValue());
-        assertThat(result.size(), greaterThan(0));
+        List<MarketOrdersResponse> lastPage = api.getMarketsRegionIdOrders(orderType, REGION_ID_THE_FORGE, DATASOURCE, null, xPages, null);
+        assertThat(lastPage.size(), greaterThan(0));
     }
 }

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.defaultLogLevel=debug


### PR DESCRIPTION
A summary of small changes, live already for https://evemissioneer.com

- Configuration class now has useragent property. Applied as before (specific > environment property > ESI static string)
- Useragent used for both OAuth (not present before) and API requests
- added debug logging to follow API call url + method
- Minor update to POM description. Added logging dependency for tests + test-only properties file to enable debug during tests
- Update deprecated RequestBody.create() calls
- Added minor debug logging for OAuth steps
- MarketAPITest does not need to download hundreds of pages. It now checks page 1, part 2 and final page. First page now has assert